### PR TITLE
Improve: don't swallow exceptions in .js config

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,15 +42,10 @@ function loadConfFiles(files) {
 			try {
 				contents = require(path.join(confDir, file + '.json'));
 			} catch (e) {
-				try {
-					contents = require(path.join(confDir, file + '.js'));
-				} catch (e2) {
-					contents = { };
-				}
+				contents = require(path.join(confDir, file + '.js'));
 			}
 			return contents;
 		})
 	);
 }
-
 


### PR DESCRIPTION
Swallowing exceptions is bad. We want to [fail fast](https://en.wikipedia.org/wiki/Fail-fast) if there's a problem.