### PR TITLE
Fix load conf files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,51 +1,51 @@
-
-var path   = require('path');
-var merge  = require('merge-recursive');
+var path = require('path');
+var merge = require('merge-recursive');
 var configLoaded = '';
 
-var cache = { };
+var cache = {};
 
 // Root path of the project
 var ROOT_DIR = path.join(__dirname, '../../..');
-exports.setRootDir = function(root) {
-	ROOT_DIR = root;
+exports.setRootDir = function (root) {
+    ROOT_DIR = root;
 };
 
 // Configuration directory
 var CONF_DIR = 'config';
-exports.setConfDir = function(conf) {
-	CONF_DIR = conf;
+exports.setConfDir = function (conf) {
+    CONF_DIR = conf;
 };
 
 // Master config file
 var MASTER_CONF = 'master';
-exports.setMasterConf = function(master) {
-	MASTER_CONF = master;
+exports.setMasterConf = function (master) {
+    MASTER_CONF = master;
 };
 
 // Load configuration
 // only allow the first config loaded to load
 exports.load = function (env) {
-	if(!cache[env] && !configLoaded) {
-		cache[env] = loadConfFiles([MASTER_CONF, (env || 'undefined')]);
-		if(!configLoaded) configLoaded = env;
-	}
-	return cache[env] || cache[configLoaded];
+    if (!cache[env] && !configLoaded) {
+        cache[env] = loadConfFiles([MASTER_CONF, env]);
+        if (!configLoaded) configLoaded = env || 'undefined';
+    }
+    return cache[env] || cache[configLoaded];
 };
 
 // Loads configuration files and merges them
 function loadConfFiles(files) {
-	var confDir = path.resolve(ROOT_DIR, CONF_DIR);
-	return merge.recursive.apply(merge,
-		files.map(function(file) {
-			var contents;
-			try {
-				contents = require(path.join(confDir, file + '.json'));
-			} catch (e) {
-				contents = require(path.join(confDir, file + '.js'));
-			}
-			return contents;
-		})
-	);
+    var confDir = path.resolve(ROOT_DIR, CONF_DIR);
+    return merge.recursive.apply(merge,
+        files.map(function (file) {
+            var contents = {};
+            if (file) {
+                try {
+                    contents = require(path.join(confDir, file + '.json'));
+                } catch (e) {
+                    contents = require(path.join(confDir, file + '.js'));
+                }
+            }
+            return contents;
+        })
+    );
 }
-


### PR DESCRIPTION
```
var conf = require('node-conf');
var config = conf.load(process.env.NODE_ENV);
```
Must not throw an exception when "NODE_ENV" isn't defined as it must load the the master config.
The changes on #1 make it throw exceptions as on line 45 would try to require a "undefined.js" and the try-catch block was silecing it before.